### PR TITLE
Open markdown reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ A prompt will pop up asking for the text to search for, defaulting to the
 highlighted text. Hit `<enter>` to run the search. A results window will pop up
 with the following keymaps:
 
-- `<tab>` - Jump to next search result
-- `<S-tab>` - Jump to the previous result
-- `o` - open the link for the result under the cursor in your browser
-- `<enter>` - accept the result under the cursor
-- `q` - quit out of the quicklink adventure
+- `<tab>` - Jump to next search result;
+- `<S-tab>` - Jump to the previous result;
+- `o` - open the link for the result under the cursor in your browser;
+- `<enter>` - accept the result under the cursor;
+- `q` - quit out of the quicklink adventure.
 
 ### Link Opening
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,13 @@ the search. A results window will pop up with the following keymaps:
 - `q` - quit out of the quicklink adventure
 
 Additionally, the plugin lets you open a markdown reference (`[reference][]`) by
-pressing `gx`. One may want to change this mapping to anything (`<cr>` for e.g.)
-by modifying the `g:quicklink_open_mapping` global variable like so :
+pressing `gx`. One may want to configure a diffrent mapping than this (`<cr>`
+for e.g.) simply by mapping to the command `:MarkdownAwareGX`.
 
-```vim
-g:quicklink_open_mapping = '<cr>'
-```
-
-This functionnality uses `pi_netrw` (`:normal gx`) in order to
-open the link, so it will open it using the program specified by the global
-variable `g:netrw_browsex_viewer` (see `:h netrw-gx`). Also, `:normal gx` will
-behave normally if on normal link.
+This functionnality uses `pi_netrw` (`:normal gx`) in order to open the link, so
+it will open it using the program specified by the global variable
+`g:netrw_browsex_viewer` (see `:h netrw-gx`). Also, `:normal gx` will behave
+normally if on normal link.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the search. A results window will pop up with the following keymaps:
 - `q` - quit out of the quicklink adventure
 
 Additionally, the plugin lets you open a markdown reference (`[reference][]`) by
-pressing `gX`. One may want to change this mapping to anything (`<cr>` for e.g.)
+pressing `gx`. One may want to change this mapping to anything (`<cr>` for e.g.)
 by modifying the `g:quicklink_open_mapping` global variable like so :
 
 ```vim
@@ -30,7 +30,8 @@ g:quicklink_open_mapping = '<cr>'
 
 This functionnality uses `pi_netrw` (`:normal gx`) in order to
 open the link, so it will open it using the program specified by the global
-variable `g:netrw_browsex_viewer` (see `:h netrw-gx`).
+variable `g:netrw_browsex_viewer` (see `:h netrw-gx`). Also, `:normal gx` will
+behave normally if on normal link.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ into a markdown document.
 Usage
 -----
 
-Start by visually selecting the word or phrase you want to add a link around,
-then press `<C-k>` to activate the plugin. A prompt will pop up asking for the
-text to search for, defaulting to the highlighted text. Hit `<enter>` to run
-the search. A results window will pop up with the following keymaps:
+### URL Searching
+
+The main feature of `vim-quicklink` is to search for and insert a relevant link
+without needing to leave vim. You can do this by visually selecting the word or
+phrase you want to add a link around, then press `<C-k>` to activate the plugin.
+A prompt will pop up asking for the text to search for, defaulting to the
+highlighted text. Hit `<enter>` to run the search. A results window will pop up
+with the following keymaps:
 
 - `<tab>` - Jump to next search result
 - `<S-tab>` - Jump to the previous result
@@ -20,14 +24,13 @@ the search. A results window will pop up with the following keymaps:
 - `<enter>` - accept the result under the cursor
 - `q` - quit out of the quicklink adventure
 
-Additionally, the plugin lets you open a markdown reference (`[reference][]`) by
-pressing `gx`. One may want to configure a diffrent mapping than this (`<cr>`
-for e.g.) simply by mapping to the command `:MarkdownAwareGX`.
+### Link Opening
 
-This functionnality uses `pi_netrw` (`:normal gx`) in order to open the link, so
-it will open it using the program specified by the global variable
-`g:netrw_browsex_viewer` (see `:h netrw-gx`). Also, `:normal gx` will behave
-normally if on normal link.
+`vim-quicklink` also updates the `gx` mapping from `netrw` to work with markdown
+link format. The default behavior of `gx` when your cursor is over a URL will
+still work and is unchanged, but you can now also use `gx` on a markdown link
+such as `[webapi-vim][]` in this readme and `vim-quicklink` will find and open
+the associated URL using `netrw`.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage
 
 Start by visually selecting the word or phrase you want to add a link around,
 then press `<C-k>` to activate the plugin. A prompt will pop up asking for the
-text to search for, defaulting to the hihglighted text. Hit `<enter>` to run
+text to search for, defaulting to the highlighted text. Hit `<enter>` to run
 the search. A results window will pop up with the following keymaps:
 
 - `<tab>` - Jump to next search result
@@ -19,6 +19,18 @@ the search. A results window will pop up with the following keymaps:
 - `o` - open the link for the result under the cursor in your browser
 - `<enter>` - accept the result under the cursor
 - `q` - quit out of the quicklink adventure
+
+Additionally, the plugin lets you open a markdown reference (`[reference][]`) by
+pressing `gX`. One may want to change this mapping to anything (`<cr>` for e.g.)
+by modifying the `g:quicklink_open_mapping` global variable like so :
+
+```vim
+g:quicklink_open_mapping = '<cr>'
+```
+
+This functionnality uses `pi_netrw` (`:normal gx`) in order to
+open the link, so it will open it using the program specified by the global
+variable `g:netrw_browsex_viewer` (see `:h netrw-gx`).
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ with the following keymaps:
 link format. The default behavior of `gx` when your cursor is over a URL will
 still work and is unchanged, but you can now also use `gx` on a markdown link
 such as `[webapi-vim][]` in this readme and `vim-quicklink` will find and open
-the associated URL using `netrw`.
+the associated URL using `netrw`. All keymaps :
+
+- `gx` - Open link under cursor;
+- `gl` - Go to link defintion under cursor.
 
 Installation
 ------------

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -119,7 +119,11 @@ function! s:CaptureLinkText()
 endfunction
 
 function! s:OpenWithNetrw() 
-  call netrw#BrowseX(expand("<cfile>"),0) 
+  if has("patch-7.4.567")
+    call netrw#BrowseX(expand("<cfile>"),0) 
+  else
+    call netrw#NetrwBrowseX(expand("<cfile>"),0) 
+  endif
 endfunction
 
 function! s:OpenMarkdownLink()

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -129,11 +129,6 @@ function! s:MarkdownAwareGX()
 endfunction
 
 command! MarkdownAwareGX call <sid>MarkdownAwareGX()
-if !exists('g:quicklink_open_mapping')
-  let g:quicklink_open_mapping = 'gx'
-endif
-if g:quicklink_open_mapping != ''
-  execute 'nnoremap <buffer> '.g:quicklink_open_mapping.' :MarkdownAwareGX<cr>'
-endif
+nmap <buffer> gx :MarkdownAwareGX<cr>
 
 vnoremap <buffer> <C-k> :call ConvertVisualSelectionToLink()<cr>

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -1,3 +1,8 @@
+" File: quicklink.vim
+" Author: Chris Toomey <chris@ctoomey.com>
+" Description: Markdown formatted link search, copy&paste and opening.
+" Last Modified: February 17, 2015
+
 let s:MARKDOWN_LINK_SYNTAX_IDS = [
   \ "markdownLinkText",
   \ "markdownLinkTextDelimiter",

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -6,8 +6,10 @@
 let s:MARKDOWN_LINK_SYNTAX_IDS = [
   \ "markdownLinkText",
   \ "markdownLinkTextDelimiter",
+  \ "markdownIdDeclaration",
   \ "mkdLink",
-  \ "mkdDelimiter"
+  \ "mkdDelimiter",
+  \ "mkdLinkDef"
   \ ]
 
 function! ConvertVisualSelectionToLink(...)

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -130,7 +130,7 @@ function! s:OpenMarkdownLink()
   let initial_pos = getpos('.')
   let escaped_link_name = s:CaptureLinkText()
   let link_target_pattern = '\v^\['.escaped_link_name.'\]: (%(ftp[s]?|http[s]?):\/\/\S+)>'
-  if search(link_target_pattern, 'e')
+  if search(link_target_pattern, 'ce')
     call s:OpenWithNetrw()
   endif
   call setpos('.', initial_pos)

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -1,3 +1,10 @@
+let s:MARKDOWN_LINK_SYNTAX_IDS = [
+  \ "markdownLinkText",
+  \ "markdownLinkTextDelimiter",
+  \ "mkdLink",
+  \ "mkdDelimiter"
+  \ ]
+
 function! ConvertVisualSelectionToLink(...)
   if a:0 == 0
     normal gv"vy
@@ -96,11 +103,9 @@ function! OpenLinkOnCurrentLine()
 endfunction
 
 function! s:OnMarkdownLink()
-    return synIDattr(synID(line("."),col("."),1),"name") == "markdownLinkText" ||
-                \ synIDattr(synID(line("."),col("."),1),"name") == "markdownLinkTextDelimiter" ||
-                \ synIDattr(synID(line("."),col("."),1),"name") == "mkdLink" ||
-                \ synIDattr(synID(line("."),col("."),1),"name") == "mkdDelimiter"
-endf
+  let current_syntax_id = synIDattr(synID(line("."), col("."), 1), "name")
+  return count(s:MARKDOWN_LINK_SYNTAX_IDS, current_syntax_id) != 0
+endfunction
 
 function! s:OpenMarkdownLink()
   "get the initial position of the curosr

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -140,7 +140,7 @@ function! s:MarkdownAwareGX()
   if s:OnMarkdownLink()
     call s:OpenMarkdownLink()
   else
-    call netrw#BrowseX(expand("<cfile>"),0)
+    call s:OpenWithNetrw()
   endif
 endfunction
 

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -107,20 +107,22 @@ function! s:OnMarkdownLink()
   return count(s:MARKDOWN_LINK_SYNTAX_IDS, current_syntax_id) != 0
 endfunction
 
-function! s:OpenMarkdownLink()
-  "get the initial position of the curosr
-  let initial_pos = getpos('.')
-  "empty the @a register in the case cursor is not well palced and that old
-  "patterns would still trigger.
+function! s:CaptureLinkText()
   let @a = ""
   normal "ayi]
-  let escaped_link_name = escape(getreg('a'), '&')
+  return escape(getreg('a'), '&')
+endfunction
+
+function! s:OpenWithNetrw() 
+  call netrw#BrowseX(expand("<cfile>"),0) 
+endfunction
+
+function! s:OpenMarkdownLink()
+  let initial_pos = getpos('.')
+  let escaped_link_name = s:CaptureLinkText()
   let link_target_pattern = '\v^\['.escaped_link_name.'\]: (%(ftp[s]?|http[s]?):\/\/\S+)>'
-  " go to link location
-  let found = search(link_target_pattern, 'e')
-  if found
-    "use netrw-gx to open the link
-    call netrw#BrowseX(expand("<cfile>"),0)
+  if search(link_target_pattern, 'e')
+    call s:OpenWithNetrw()
   endif
   call setpos('.', initial_pos)
 endfunction
@@ -134,6 +136,6 @@ function! s:MarkdownAwareGX()
 endfunction
 
 command! MarkdownAwareGX call <sid>MarkdownAwareGX()
-nmap <buffer> gx :MarkdownAwareGX<cr>
+nnoremap <buffer> gx :MarkdownAwareGX<cr>
 
 vnoremap <buffer> <C-k> :call ConvertVisualSelectionToLink()<cr>

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -128,11 +128,17 @@ function! s:OpenWithNetrw()
   endif
 endfunction
 
+function! s:GoToLinkDefinition(link_name)
+  let link_target_pattern = '\v^\['.a:link_name.'\]: (%(ftp[s]?|http[s]?):\/\/\S+)>'
+  let found = search(link_target_pattern, 'ce')
+  normal B
+  return found
+endfunction
+
 function! s:OpenMarkdownLink()
   let initial_pos = getpos('.')
   let escaped_link_name = s:CaptureLinkText()
-  let link_target_pattern = '\v^\['.escaped_link_name.'\]: (%(ftp[s]?|http[s]?):\/\/\S+)>'
-  if search(link_target_pattern, 'ce')
+  if s:GoToLinkDefinition(escaped_link_name)
     call s:OpenWithNetrw()
   endif
   call setpos('.', initial_pos)
@@ -148,5 +154,8 @@ endfunction
 
 command! MarkdownAwareGX call <sid>MarkdownAwareGX()
 nnoremap <buffer> gx :MarkdownAwareGX<cr>
+
+command! GoToLinkDefinition call <sid>GoToLinkDefinition(<sid>CaptureLinkText())
+nnoremap <buffer> gl :GoToLinkDefinition<cr>
 
 vnoremap <buffer> <C-k> :call ConvertVisualSelectionToLink()<cr>

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -95,7 +95,14 @@ function! OpenLinkOnCurrentLine()
   call system('open ' . expand('<cWORD>'))
 endfunction
 
-function! s:OpenLink()
+function! s:OnMarkdownLink()
+    return synIDattr(synID(line("."),col("."),1),"name") == "markdownLinkText" ||
+                \ synIDattr(synID(line("."),col("."),1),"name") == "markdownLinkTextDelimiter" ||
+                \ synIDattr(synID(line("."),col("."),1),"name") == "mkdLink" ||
+                \ synIDattr(synID(line("."),col("."),1),"name") == "mkdDelimiter"
+endf
+
+function! s:OpenMarkdownLink()
   "get the initial position of the curosr
   let initial_pos = getpos('.')
   "empty the @a register in the case cursor is not well palced and that old

--- a/ftplugin/markdown/quicklink.vim
+++ b/ftplugin/markdown/quicklink.vim
@@ -110,22 +110,30 @@ function! s:OpenMarkdownLink()
   let @a = ""
   normal "ayi]
   let escaped_link_name = escape(getreg('a'), '&')
-  let pattern = '\v^\['.escaped_link_name.'\]: (%(ftp[s]?|http[s]?):\/\/\S+)>'
+  let link_target_pattern = '\v^\['.escaped_link_name.'\]: (%(ftp[s]?|http[s]?):\/\/\S+)>'
   " go to link location
-  let found = search(pattern, 'e')
+  let found = search(link_target_pattern, 'e')
   if found
     "use netrw-gx to open the link
-    normal gx
+    call netrw#BrowseX(expand("<cfile>"),0)
   endif
   call setpos('.', initial_pos)
 endfunction
 
-command! OpenMarkdownLink call s:OpenLink()
+function! s:MarkdownAwareGX()
+  if s:OnMarkdownLink()
+    call s:OpenMarkdownLink()
+  else
+    call netrw#BrowseX(expand("<cfile>"),0)
+  endif
+endfunction
+
+command! MarkdownAwareGX call <sid>MarkdownAwareGX()
 if !exists('g:quicklink_open_mapping')
-  let g:quicklink_open_mapping = 'gX'
+  let g:quicklink_open_mapping = 'gx'
 endif
 if g:quicklink_open_mapping != ''
-  execute 'nnoremap <buffer> '.g:quicklink_open_mapping.' :OpenMarkdownLink<cr>'
+  execute 'nnoremap <buffer> '.g:quicklink_open_mapping.' :MarkdownAwareGX<cr>'
 endif
 
 vnoremap <buffer> <C-k> :call ConvertVisualSelectionToLink()<cr>

--- a/plugin/quicklink.vim
+++ b/plugin/quicklink.vim
@@ -95,4 +95,22 @@ function! OpenLinkOnCurrentLine()
   call system('open ' . expand('<cWORD>'))
 endfunction
 
+function! s:OpenLink()
+  "get the initial position of the curosr
+  let initial_pos = getpos('.')
+  "empty the @a register in the case cursor is not well palced and that old
+  "patterns would still trigger.
+  let @a = ""
+  normal "ayi]
+  let escaped_link_name = escape(getreg('a'), '&')
+  let pattern = '\v^\['.escaped_link_name.'\]: (%(ftp[s]?|http[s]?):\/\/\S+)>'
+  " go to link location
+  let found = search(pattern, 'e')
+  if found
+    "use netrw-gx to open the link
+    normal gx
+  endif
+  call setpos('.', initial_pos)
+endfunction
+
 vnoremap <C-k> :call ConvertVisualSelectionToLink()<cr>

--- a/plugin/quicklink.vim
+++ b/plugin/quicklink.vim
@@ -113,4 +113,12 @@ function! s:OpenLink()
   call setpos('.', initial_pos)
 endfunction
 
+command! OpenMarkdownLink call s:OpenLink()
+if !exists('g:quicklink_open_mapping')
+  let g:quicklink_open_mapping = 'gX'
+endif
+if g:quicklink_open_mapping != ''
+  execute 'nnoremap <buffer> '.g:quicklink_open_mapping.' :OpenMarkdownLink<cr>'
+endif
+
 vnoremap <C-k> :call ConvertVisualSelectionToLink()<cr>


### PR DESCRIPTION
I've added a functionnality for opening a markdown reference under the cursor. It has be inspired by @christoomey's [function](https://github.com/christoomey/dotfiles/blob/f3f9da69586503823de9ff075fbf627ec2bb6fb5/vim/rcfiles/prose#L90-L106). In order not to depend on any (I *hope* I'm not mistaking here...) platform, I've chosen to use `:normal gx` from Vim's `pi_netrw` plugin (which comes with **Vim 7.4**, I guess).

PLUS : I've fixed a minor typo inside the README file ! ;)